### PR TITLE
feat: Add page related info to the page title

### DIFF
--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -38,7 +38,7 @@ if (package) {
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title><?js= name ?></title>
+    <title><?js= name + ' | ' + title ?></title>
 
     <script src="scripts/prettify/prettify.js"> </script>
     <script src="scripts/prettify/lang-css.js"> </script>


### PR DESCRIPTION
This adds the page name in addition to the project name to `<title>` element.

![image](https://cloud.githubusercontent.com/assets/441011/20234447/b7bd9ef8-a87b-11e6-995a-f9adb127c444.png)
