### PR TITLE
feat: version switcher

### DIFF
--- a/demo/jsdoc-conf.json
+++ b/demo/jsdoc-conf.json
@@ -6,7 +6,8 @@
   },
   "templates": {
     "name": "Doc Template",
-    "footerText": "NHN Entertainment Frontend Development Lab"
+    "footerText": "NHN Entertainment Frontend Development Lab",
+    "versionSwitcher": true
   },
   "opts": {
     "encoding": "utf8",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,7 +52,8 @@ var watchPaths = [
     'static/scripts/**/*.js',
     'static/styles/**/*.css',
     'tmpl/**/*.tmpl',
-    'publish.js'
+    'publish.js',
+    'versionSwitcher/**/*'
 ];
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "cheerio": "^0.22.0"
   },
   "devDependencies": {
+    "bluebird": "^3.4.6",
     "del": "^2.2.2",
+    "git-semver-tags": "^1.1.2",
     "gulp": "^3.9.1",
     "gulp-connect": "^5.0.0",
     "gulp-jsdoc3": "^1.0.1"

--- a/publish.js
+++ b/publish.js
@@ -10,6 +10,7 @@ var taffy = require('taffydb').taffy;
 var template = require('jsdoc/template');
 var util = require('util');
 var cheerio = require('cheerio'); // for parse html to dom
+var generateVersionSwitcher = require('./versionSwitcher');
 
 var htmlsafe = helper.htmlsafe;
 var linkto = helper.linkto;
@@ -551,6 +552,11 @@ exports.publish = function(taffyData, opts, tutorials) {
         }
     });
 
+    // update outdir if necessary, then create outdir
+    var packageInfo = ( find({kind: 'package'}) || [] ) [0];
+    if (packageInfo && packageInfo.version && conf.versionSwitcher) {
+        outdir = path.join( outdir, (packageInfo.version) );
+    }
     fs.mkPath(outdir);
 
     // copy the template's static files to outdir
@@ -756,4 +762,9 @@ exports.publish = function(taffyData, opts, tutorials) {
         });
     }
     saveChildren(tutorials);
+
+    // Generate versionSwitcher
+    if (packageInfo && packageInfo.version && conf.versionSwitcher) {
+        generateVersionSwitcher(env.opts.destination, packageInfo.version, conf.name || packageInfo.name);
+    }
 };

--- a/versionSwitcher/index.js
+++ b/versionSwitcher/index.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var fs = require('jsdoc/fs');
+var path = require('jsdoc/path');
+var Promise = require('bluebird');
+var gitSemverTags = Promise.promisify(require('git-semver-tags'));
+
+/**
+ * [exports description]
+ * @param  {String} outputDir      Path to the output folder for the generated documentation
+ * @param  {String} currentVersion Current version from package.json
+ * @param  {String} pageTitle      Used as content of the <title> element of the page
+ */
+module.exports = function (outputDir, currentVersion, pageTitle) {
+    var staticJSDocTemplateDir = path.normalize(path.join(__dirname, '../static'));
+    var versionSwitcherOutputDir;
+    var staticVersionSwitcherDir;
+    var versionSwitcherData = {
+        currentVersion: currentVersion,
+        pageTitle: pageTitle
+    };
+
+    // Prepare directories
+    outputDir = path.normalize(outputDir);
+    fs.mkdirSync(path.join(outputDir, 'versionSwitcher'));
+    versionSwitcherOutputDir = path.normalize(path.join(outputDir, 'versionSwitcher'));
+    staticVersionSwitcherDir = path.normalize(__dirname + '/static');
+
+    // Copy files from `/static` to {outputDir}/versionSwitcher
+    fs.copyFileSync(path.normalize(staticJSDocTemplateDir + '/scripts/jquery.min.js'), versionSwitcherOutputDir);
+    fs.copyFileSync(path.normalize(staticJSDocTemplateDir + '/styles/bootstrap.min.css'), versionSwitcherOutputDir);
+
+    // Copy index.html from `/versionSwitcher/static` to {outputDir}
+    fs.copyFileSync(path.normalize(staticVersionSwitcherDir + '/index.html'), outputDir);
+
+    // Copy files from `/versionSwitcher/static` to {outputDir}/versionSwitcher
+    fs.copyFileSync(path.normalize(staticVersionSwitcherDir + '/versionSwitcher.css'), versionSwitcherOutputDir);
+    fs.copyFileSync(path.normalize(staticVersionSwitcherDir + '/versionSwitcher.js'), versionSwitcherOutputDir);
+
+    // Git versions from Git tags and generate {outputDir}/versionSwitcher/data.js
+    gitSemverTags().then(function(versions){
+        versionSwitcherData.versions = versions;
+        fs.writeFileSync(path.normalize(versionSwitcherOutputDir + '/data.js'), 'var data = ' + JSON.stringify(versionSwitcherData) + ';');
+    });
+
+};

--- a/versionSwitcher/static/index.html
+++ b/versionSwitcher/static/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title></title>
+    <link rel="stylesheet" href="versionSwitcher/bootstrap.min.css">
+    <link rel="stylesheet" href="versionSwitcher/versionSwitcher.css">
+</head>
+<body>
+    <div class="">
+        <script>
+            //document.write('v', data.currentVersion);
+        </script>
+    </div>
+    <form class="form-inline version-switcher">
+        <div class="form-group">
+          <label for="selectVersion">Version:</label>
+          <select id="selectVersion" class="form-control"></select>
+        </div>
+    </form>
+
+    <iframe id="docs" src='./1.0.4'></iframe>
+    <script src="versionSwitcher/jquery.min.js"></script>
+    <script src="versionSwitcher/data.js"></script>
+    <script src="versionSwitcher/versionSwitcher.js"></script>
+</body>
+</html>

--- a/versionSwitcher/static/versionSwitcher.css
+++ b/versionSwitcher/static/versionSwitcher.css
@@ -1,0 +1,27 @@
+body {
+    overflow: hidden;
+}
+
+.version-switcher {
+    height: 40px;
+    color: #fff;
+    font-size: 13px;
+    background-color: #00beaa;
+    padding: 8px 17px;
+}
+.version-switcher label {
+    font-weight: normal;
+}
+.version-switcher .form-control {
+    min-width: 80px;
+    height: 25px;
+    font-size: 13px;
+}
+
+#docs {
+    height: 90%; /* Fallback for browser which doesnt support calc() */
+    height: calc(100% - 40px);
+    border: none;
+    width: 100%;
+    position: absolute;
+}

--- a/versionSwitcher/static/versionSwitcher.js
+++ b/versionSwitcher/static/versionSwitcher.js
@@ -1,0 +1,19 @@
+$(function () {
+
+    var $versionSwitcher = $('#selectVersion');
+    var options = [];
+
+    $.each(data.versions, function(index, version) {
+        // Get rid of semver version prefixes
+        version = version.replace('v', '');
+
+        options.push('<option value="' + version + '">v' + version +'</option>');
+    });
+
+    $versionSwitcher.html(options);
+
+    $versionSwitcher.on('change', function (e) {
+        $('#docs').attr('src', './' + e.target.value);
+    });
+
+});


### PR DESCRIPTION
Hej, here’s the implementation of option 3 of the version switcher as proposed in #5.

Must say that I prefer it over the implementation of option 1 in #9 

Pros:
- You can switch from older version to newer 
- Less changes in `publish.js`
  - Makes it easier to integrate future changes from JSDocs default template

Cons:
- We are loosing the custom page titles from the docs
  - Cause we only see the output from the `<title>` Element of the page holding that iFrame

Closes #5 