### PR TITLE
feat: allow custom styles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,33 @@ TUI JSDoc template has following features.
 }
 ```
 
+### Custom Styles
+With a folder structure like this:
+```
+static
+└── styles
+    └── custom.css
+    └── another.css
+```
+And a config like this:
+```js
+"templates": {
+    "default": {
+        "staticFiles": {
+            "include": ["static/"]
+        }
+    },
+    "css": [
+        "styles/custom.css",
+        "styles/another.css",
+        "http://example.com/remote.css"
+    ]
+}
+```
+
+`styles/custom.css`, `styles/another.css`, and `remote.css` get included in the layout.
+`default.staticFiles` is the build-in jsdoc way of copying extra files.
+
 <br>
 ## Expose the html/js code to exmaple page
 If `script` or `div` elements have `code-js` or `code-html` class, expose their innerHTML.

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -1,6 +1,7 @@
 <?js
 var templates = env.conf.templates;
 var examples = env.conf.opts.tutorials;
+var css = templates.css;
 var logo = '';
 var footerText = '';
 var logoUrl = 'img/toast-ui.png';
@@ -49,6 +50,12 @@ if (package) {
     <link type="text/css" rel="stylesheet" href="styles/prettify-jsdoc.css">
     <link type="text/css" rel="stylesheet" href="styles/prettify-tomorrow.css">
     <link type="text/css" rel="stylesheet" href="styles/tui-doc.css">
+
+    <?js if (css) { ?>
+        <?js css.forEach(function(style) { ?>
+            <link type="text/css" rel="stylesheet" href="<?js= style ?>">
+        <?js }) ?>
+    <?js } ?>
 </head>
 <body>
 <nav class="lnb" id="lnb">


### PR DESCRIPTION
Uses jsdoc's staticFiles feature to copy the files over.
Then, the `css` property of `templates` is used to include these styles
in the layout.

For example:
With a folder structure like this:
```
static
└── styles
    └── custom.css
```
And a config like this:
```js
{
  "templates": {
    "default": {
      "staticFiles": {
        "include": ["static/"]
      }
    },
    "css": ["styles/custom.css"]
}
```

`styles/custom.css` gets included in the layout.

Fixes #15.