### PR TITLE
fix: add page title to title element

### DIFF
--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -38,7 +38,7 @@ if (package) {
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title><?js= name ?></title>
+    <title><?js= title ?> - <?js= name ?></title>
 
     <script src="scripts/prettify/prettify.js"> </script>
     <script src="scripts/prettify/lang-css.js"> </script>


### PR DESCRIPTION
This adds the title to the title element of the page. This means that on
a tutorial page, the title would read `Tutorial: Foo - tui-jsdoc-template` instead of just reading `tui-jsdoc-template`.