### PR TITLE
feat: allow Examples name to be changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ TUI JSDoc template has following features.
 ### Tab Names
 ```
 "templates": {
-    "api": "API",
-    "tutorials": "Examples"
+    "tabNames": {
+        "api": "API",
+        "tutorials": "Examples"
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ TUI JSDoc template has following features.
 }
 ```
 
+### Tab Names
+```
+"templates": {
+    "api": "API",
+    "tutorials": "Examples"
+}
+```
+
+`api` defaults to the value `API` and `tutorials` defaults to the value `Examples`.
+
 <br>
 ## Expose the html/js code to exmaple page
 If `script` or `div` elements have `code-js` or `code-html` class, expose their innerHTML.

--- a/publish.js
+++ b/publish.js
@@ -23,6 +23,11 @@ var data;
 var view;
 
 var outdir = path.normalize(env.opts.destination);
+var examplesName = 'Examples';
+
+if (env.conf.templates) {
+  examplesName = env.conf.templates.examplesName || examplesName;
+}
 
 // Set default useCollapsibles true
 env.conf.templates.useCollapsibles = env.conf.templates.useCollapsibles !== false;
@@ -355,7 +360,7 @@ function buildMemberNav(items, itemHeading, itemsSeen, linktoFn) {
 
     if (items.length) {
         var itemsNav = '';
-        var className = itemHeading === 'Examples' ? 'lnb-examples hidden' : 'lnb-api hidden';
+        var className = itemHeading === examplesName ? 'lnb-examples hidden' : 'lnb-api hidden';
         var makeHtml = env.conf.templates.useCollapsibles ? makeCollapsibleItemHtmlInNav : makeItemHtmlInNav;
 
         items.forEach(function(item) {
@@ -429,7 +434,7 @@ function buildNav(members) {
     var seen = {};
     var seenTutorials = {};
 
-    nav += buildMemberNav(members.tutorials, 'Examples', seenTutorials, linktoTutorial, true);
+    nav += buildMemberNav(members.tutorials, examplesName, seenTutorials, linktoTutorial, true);
     nav += buildMemberNav(members.modules, 'Modules', {}, linkto);
     nav += buildMemberNav(members.externals, 'Externals', seen, linktoExternal);
     nav += buildMemberNav(members.classes, 'Classes', seen, linkto);

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -8,11 +8,13 @@ var width, height;
 var style = '';
 var name = '';
 var version = '';
+var examplesName = '';
 
 if (templates) {
     logo = templates.logo;
     footerText = templates.footerText;
     name = templates.name || package.name || title;
+    examplesName = templates.examplesName || 'Examples';
 }
 
 if (logo) {
@@ -71,7 +73,7 @@ if (package) {
                 <a href="#"><h4>API</h4></a>
             </li>
             <li id="examples-tab">
-                <a href="#"><h4>Examples</h4></a>
+                <a href="#"><h4><?js= examplesName ?></h4></a>
             </li>
         </ol>
     <?js } ?>

--- a/tmpl/layout.tmpl
+++ b/tmpl/layout.tmpl
@@ -9,12 +9,14 @@ var style = '';
 var name = '';
 var version = '';
 var examplesName = '';
+var apiName = '';
 
 if (templates) {
     logo = templates.logo;
     footerText = templates.footerText;
     name = templates.name || package.name || title;
-    examplesName = templates.examplesName || 'Examples';
+    examplesName = templates.tabNames.tutorials || 'Examples';
+    apiName = templates.tabNames.api || 'API'
 }
 
 if (logo) {
@@ -70,7 +72,7 @@ if (package) {
     <?js if (examples) { ?>
         <ol class="lnb-tab">
             <li id="api-tab">
-                <a href="#"><h4>API</h4></a>
+                <a href="#"><h4><?js= apiName ?></h4></a>
             </li>
             <li id="examples-tab">
                 <a href="#"><h4><?js= examplesName ?></h4></a>


### PR DESCRIPTION
Look for `conf.templates.examplesName` to use instead of "Examples" and
default to "Examples".